### PR TITLE
Real multiplication signs: 1024x1024 → 1024×1024

### DIFF
--- a/AppIcons/Base.lproj/Main.storyboard
+++ b/AppIcons/Base.lproj/Main.storyboard
@@ -768,7 +768,7 @@
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" id="GJk-ZR-lmD">
                                                 <font key="font" metaFont="system"/>
                                                 <string key="title">For better results use
-a 1024x1024 image</string>
+a 1024×1024 image</string>
                                                 <color key="textColor" red="0.0" green="0.25098040700000002" blue="0.50196081400000003" alpha="1" colorSpace="calibratedRGB"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # AppIcon Generator for macOS and iOS
 
-AppIcons is a tool for generating icons in all sizes as required by macOS and iOS apps. Just select an image in 1024x1024 pixels and the app will generate all icons in normal and high resolution.
+AppIcons is a tool for generating icons in all sizes as required by macOS and iOS apps. Just select an image in 1024×1024 pixels and the app will generate all icons in normal and high resolution.
 
 ![Screenshot](https://raw.githubusercontent.com/kuyawa/Gallery/master/AppIcons/appicons.png)
 


### PR DESCRIPTION
Use the multiplication sign × instead of the letter 𝑥 for dimensions.

This pull is compatible with my [pull to upgrade to Swift 5.0](https://github.com/kuyawa/AppIcons/pull/5).